### PR TITLE
Disable spellchecker

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -35,6 +35,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: tbroadley/spellchecker-cli-action@v1
       with:
-        dictionaries: '.github/workflows/dictionary.txt'
+        # No need to use a dictionary file with the disabled spell plugin 
+        # dictionaries: '.github/workflows/dictionary.txt'
         files: "'content/**/*.md'"
-
+        quiet: true
+        plugins: "indefinite-article repeated-words syntax-mentions syntax-urls"


### PR DESCRIPTION
This PR disables the spell plugin in the spellchecker GH action. Also, it enables the quiet mode (do not output anything for files that contain no spelling mistakes).