### PR TITLE
Fix copy icon position on numbered code snippets

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -39,14 +39,21 @@
 
 .markdown .highlight {
   position: relative;
+  padding: 1rem 0;
+
+  > pre {
+    margin: inherit;
+  }
 
   code:first-child::before {
-    content: url('svg/copy-regular.svg');
-    width: 1rem;
-    height: 1rem;
+    content: "Copy";
+    font-size: 0;
+    background: no-repeat center url('svg/copy-regular.svg');
+    width: 1.4rem;
+    height: 1.4rem;
     position: absolute;
     right: 1rem;
-    top: 1.1rem;
+    top: 2rem;
     display: inline-block;
     opacity: 0.3;
     transition: opacity 0.1s ease-in;


### PR DESCRIPTION
Before:
![Screenshot 2024-02-08 at 21 53 52](https://github.com/trailofbits/testing-handbook/assets/2642849/172a190f-e09c-4906-af07-9ab47b732a17)
After:
![Screenshot 2024-02-08 at 21 54 40](https://github.com/trailofbits/testing-handbook/assets/2642849/7c0003d9-ffd2-4c1e-8110-2d8a4b007159)
