### PR TITLE
Center captions

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -39,7 +39,7 @@
 
 .markdown .highlight {
   position: relative;
-  // padding: 1rem 0; // Padding between the markdown code and captions
+  padding: 1rem 0;
 
   > pre {
     margin: inherit;
@@ -66,8 +66,6 @@
 }
 
 figure {
-  display: inline;
-  text-align: center;
   counter-increment: figureIndex;
 
   width: 100%;
@@ -101,10 +99,10 @@ figure {
     content: "Figure " counter(figureIndex) ": ";
   }
   figcaption {
+    text-align: center;
     max-width: 90%;
     margin-top: 5px;
     margin-bottom: 10px;
-
     font-style: italic;
 
     p:first-child  {

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -48,7 +48,7 @@
   code:first-child::before {
     content: "Copy";
     font-size: 0;
-    background: no-repeat center url('svg/copy-regular.svg');
+    background: no-repeat center url("svg/copy-regular.svg");
     width: 1.4rem;
     height: 1.4rem;
     position: absolute;
@@ -86,14 +86,9 @@ figure {
     > * {
       max-width: 95%;
     }
-  
   }
 
   //border: 2px solid var(--gray-100);
-
-
-
-
 
   figcaption::before {
     content: "Figure " counter(figureIndex) ": ";
@@ -105,7 +100,7 @@ figure {
     margin-bottom: 10px;
     font-style: italic;
 
-    p:first-child  {
+    p:first-child {
       display: inline;
     }
   }
@@ -113,9 +108,7 @@ figure {
   figcaption.code {
     margin-top: 0px; // Remove margin when a figure is code block
   }
-
 }
-
 
 p {
   // TODO: not sure if this is without side effects

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -66,6 +66,8 @@
 }
 
 figure {
+  display: inline;
+  text-align: center;
   counter-increment: figureIndex;
 
   width: 100%;
@@ -139,14 +141,4 @@ table.hide-empty-cells {
   td:empty {
     display: none;
   }
-}
-
-// Captions
-figure {
-  display: inline;
-  text-align: center;
-  margin: 5px;
-}
-figure img {
-  vertical-align: top;
 }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -39,7 +39,7 @@
 
 .markdown .highlight {
   position: relative;
-  padding: 1rem 0;
+  // padding: 1rem 0; // Padding between the markdown code and captions
 
   > pre {
     margin: inherit;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -109,6 +109,11 @@ figure {
       display: inline;
     }
   }
+
+  figcaption.code {
+    margin-top: 0px; // Remove margin when a figure is code block
+  }
+
 }
 
 

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -140,3 +140,13 @@ table.hide-empty-cells {
     display: none;
   }
 }
+
+// Captions
+figure {
+  display: inline;
+  text-align: center;
+  margin: 5px;
+}
+figure img {
+  vertical-align: top;
+}

--- a/layouts/shortcodes/customFigure.html
+++ b/layouts/shortcodes/customFigure.html
@@ -7,7 +7,7 @@
     {{ end}}
 
     {{ if (.Get 0) }}
-    <figcaption>{{ (.Get 0) | .Page.RenderString (dict "display" "inline") }}</figcaption>
+    <figcaption class="code">{{ (.Get 0) | .Page.RenderString (dict "display" "inline") }}</figcaption>
     {{ end }}
   </div>
 </figure>

--- a/layouts/shortcodes/resourceFigure.html
+++ b/layouts/shortcodes/resourceFigure.html
@@ -15,7 +15,7 @@
       <img src="{{ $img.RelPermalink }}" alt="{{ .Get 1 }}" />
     {{ end }}
     {{ if .Inner }}
-    <figcaption>{{ .Inner | .Page.RenderString (dict "display" "inline") }}</figcaption>
+    <center><figcaption>{{ .Inner | .Page.RenderString (dict "display" "inline") }}</figcaption></center>
     {{ end }}
   </div>
 </figure>

--- a/layouts/shortcodes/resourceFigure.html
+++ b/layouts/shortcodes/resourceFigure.html
@@ -15,7 +15,7 @@
       <img src="{{ $img.RelPermalink }}" alt="{{ .Get 1 }}" />
     {{ end }}
     {{ if .Inner }}
-    <center><figcaption>{{ .Inner | .Page.RenderString (dict "display" "inline") }}</figcaption></center>
+    <figcaption>{{ .Inner | .Page.RenderString (dict "display" "inline") }}</figcaption>
     {{ end }}
   </div>
 </figure>


### PR DESCRIPTION
Before:
![image](https://github.com/trailofbits/testing-handbook/assets/38883201/301678ed-088c-4253-a777-c6eea4b7f811)

After:
![image](https://github.com/trailofbits/testing-handbook/assets/38883201/9e08fc61-2043-49c4-917a-856ad6ce492d)

And reduces this margin when code:
![image](https://github.com/trailofbits/testing-handbook/assets/38883201/dcdee7d8-2833-4837-ae13-b3e922f63775)
