### PR TITLE
set color links same as in reports

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -161,3 +161,37 @@ html {
   background: var(--gray-500);
   border-radius: $padding-8;
 }
+
+
+
+// Links
+// main colors are set in _variables.scss
+a:focus, a:focus-visible {
+  opacity: .75;
+  text-decoration: none;
+  outline-style: auto;
+  outline-color: var(--color-link-mono);
+}
+
+.markdown, .book-toc {
+  a:hover {
+    opacity: .75;
+  }
+}
+
+.markdown a {
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--color-link-mono);
+  }
+
+  &:visited {
+    &:hover {
+      text-decoration-color: var(--color-visited-link-mono);
+    }
+
+    &:focus, &:focus-visible {
+      outline-color: var(--color-visited-link-mono);
+    }
+  }
+}

--- a/assets/_variables.scss
+++ b/assets/_variables.scss
@@ -1,0 +1,21 @@
+// had to copy the whole mixin from _default.scss
+@mixin theme-light {
+  --gray-100: #f8f9fa;
+  --gray-200: #e9ecef;
+  --gray-500: #adb5bd;
+
+  // https://github.com/trailofbits/audit-reporting-tools/blob/88b75a31a7298e8079fb326c7992ff534868e497/make-report/make_report/colors.py#L86
+  --color-link: #ad182b;
+  --color-link-mono: #c93447;  // monochromatic
+  --color-visited-link: #683700;
+  --color-visited-link-mono: #84531c;  // monochromatic
+
+  --body-background: white;
+  --body-font-color: black;
+
+  --icon-filter: none;
+
+  --hint-color-info: #6bf;
+  --hint-color-warning: #fd6;
+  --hint-color-danger: #f66;
+}


### PR DESCRIPTION
Red/brown links.

Cannot figure out a way to change color of active label in figures:

<img width="173" alt="image" src="https://github.com/user-attachments/assets/5b5a1130-c46b-4779-927f-c70e505d935d">
