### PR TITLE
Fixing incorrect `cd` path

### DIFF
--- a/content/docs/fuzzing/c-cpp/12-libafl/index.md
+++ b/content/docs/fuzzing/c-cpp/12-libafl/index.md
@@ -68,7 +68,7 @@ Next, clone LibAFL's source code and build the libFuzzer drop-in replacement. No
 
 ```shell
 git clone https://github.com/AFLplusplus/LibAFL
-cd LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime
+cd LibAFL/libafl_libfuzzer_runtime
 ./build.sh
 ```
 


### PR DESCRIPTION
Fixing incorrect path, should be `LibAFL/libafl_libfuzzer_runtime` instead of `LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime` (https://github.com/AFLplusplus/LibAFL/tree/main/libafl_libfuzzer_runtime)