### PR TITLE
Update AFL++ documentation with bug fixes and improvements

### DIFF
--- a/content/docs/fuzzing/c-cpp/11-aflpp/index.md
+++ b/content/docs/fuzzing/c-cpp/11-aflpp/index.md
@@ -24,7 +24,7 @@ The AFL++ fuzzer has many dependencies, such as LLVM, Python, and Rust. We recom
     <td><strong>Method</strong></td>
     <td><strong>When should I use it?</strong></td>
     <td>
-      <strong>Supported compiler versions (<code>afl-clang/afl-gcc --version</code>)</strong>
+      <strong>Supported compiler versions (<code>afl-clang-fast/afl-gcc --version</code>)</strong>
     </td>
   </tr>
   <tr>
@@ -100,14 +100,14 @@ The AFL++ fuzzer has many dependencies, such as LLVM, Python, and Rust. We recom
 If you run a recent Debian or Ubuntu version, the packaged version in the official Ubuntu repositories is an easy choice. At the time of writing, Ubuntu 23.10 packages AFL++ 4.08c and Debian 12 version 4.04c. Note that this will limit you to the Clang version supported by the packaged AFL++ version.
 
 
-Note: Check which Clang version AFL++ uses on your distribution before installing `lld`. Run `afl-cc --version` to verify, then install the matching `lld` version (e.g., `lld-16` for Clang 16).
+Note: Check which Clang version AFL++ uses on your distribution before installing `lld`. Run `afl-cc --version` to verify, then install the matching `lld` version (e.g., `lld-17`).
 
 ```shell
-apt install afl++ lld-14
+apt install afl++ lld-17
 ```
 
 
-Installing the `lld` package is required for the optional LTO mode that we will describe later. Depending on the Clang version AFL++ uses on your Linux distributions, you may want to install a specific version of `lld` like `lld-16`. Verify the output of `afl-cc --version`.
+Installing the `lld` package is required for the optional LTO mode that we will describe later. Depending on the Clang version AFL++ uses on your Linux distributions, you may want to install a specific version of `lld` like `lld-17`. Verify the output of `afl-cc --version`.
 
 
 ### Docker (from Docker Hub) {#docker-from-docker-hub}
@@ -252,7 +252,7 @@ If your project depends on the GCC compiler, then consider using the [gcc_plugin
 PRO TIP: The GCC version of your system and the GCC version that was used to compile the AFL++ GCC plugin must match. If they do not match (e.g., if you upgrade GCC), then you will get an error when using the GCC support.
 {{< /hint >}}
 
-We set the optimization level to `-O2`, which is a reasonable optimization level for fuzzing because it is likely the level used during production.
+We set the optimization level to `-O2`, which is a reasonable optimization level for fuzzing because it is likely the level used during production. Note that `-g` is not necessary, it is added by default by the AFL++ compilers.
 
 Many things are happening behind the scenes when using AFL++: 
 


### PR DESCRIPTION
## Summary

Carry over bug fixes and improvements from [trailofbits/skills PR #15](https://github.com/trailofbits/skills/pull/15) to the testing-handbook AFL++ documentation.

- Fix `-DNO_MAIN` to `-DNO_MAIN=1` for correct macro definition
- Remove redundant `-g` flags (AFL++ compilers add debug symbols by default)
- Update Docker image version from 4.09c to 4.35c (Clang 19 & GCC 11)
- Update `LLVM_CONFIG` example from `llvm-config-14` to `llvm-config-18`
- Add note about checking Clang version before installing `lld`
- Change seed content from `"a"` to `"aaaa"` (4 bytes minimum is more practical)
- Replace `AFL_PIZZA_MODE` joke with useful `AFL_FAST_CAL` example
- Fix timeout option from `-t 10000` to `-t 1000` (1s is the default)
- Fix paper title typo (`PAFL++` → `AFL++`) and stray markdown formatting
- Fix "Fuzzing in Depth" URLs (add `.md` extension)
- Fix CMake example to use `-fsanitize=fuzzer-no-link` for compilation
- Add new CMPLOG section explaining RedQueen path constraint solving
- Remove outdated legacy Clang mode references

## Test plan

- [ ] Verify Hugo builds successfully
- [ ] Review rendered AFL++ page for correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)