### PR TITLE
Shorten C/C++ slugs and add aliases for old URLs

### DIFF
--- a/content/docs/languages/c-cpp/10-bug-classes.md
+++ b/content/docs/languages/c-cpp/10-bug-classes.md
@@ -1,6 +1,8 @@
 ---
 title: "Bug classes"
-slug: lang-c-cpp-bug-classes
+slug: bug-classes
+aliases:
+- lang-c-cpp-bug-classes
 weight: 10
 ---
 

--- a/content/docs/languages/c-cpp/12-linux-usermode.md
+++ b/content/docs/languages/c-cpp/12-linux-usermode.md
@@ -1,6 +1,8 @@
 ---
 title: "Linux usermode"
-slug: lang-c-cpp-linux-usermode
+slug: linux-usermode
+aliases:
+- lang-c-cpp-linux-usermode
 weight: 12
 ---
 

--- a/content/docs/languages/c-cpp/14-linux-kernelmode.md
+++ b/content/docs/languages/c-cpp/14-linux-kernelmode.md
@@ -1,6 +1,8 @@
 ---
 title: "Linux Kernel"
-slug: lang-c-cpp-linux-kernelmode
+slug: linux-kernelmode
+aliases:
+- lang-c-cpp-linux-kernelmode
 weight: 14
 ---
 

--- a/content/docs/languages/c-cpp/16-windows-usermode.md
+++ b/content/docs/languages/c-cpp/16-windows-usermode.md
@@ -1,6 +1,8 @@
 ---
 title: "Windows usermode"
-slug: lang-c-cpp-windows-usermode
+slug: windows-usermode
+aliases:
+- lang-c-cpp-windows-usermode
 weight: 16
 ---
 

--- a/content/docs/languages/c-cpp/18-windows-kernelmode.md
+++ b/content/docs/languages/c-cpp/18-windows-kernelmode.md
@@ -1,6 +1,8 @@
 ---
 title: "Windows kernel"
-slug: lang-c-cpp-windows-kernelmode
+slug: windows-kernelmode
+aliases:
+- lang-c-cpp-windows-kernelmode
 weight: 18
 ---
 

--- a/content/docs/languages/c-cpp/20-seccomp.md
+++ b/content/docs/languages/c-cpp/20-seccomp.md
@@ -1,6 +1,8 @@
 ---
 title: "Seccomp/BPF"
-slug: lang-c-cpp-seccomp
+slug: seccomp
+aliases:
+- lang-c-cpp-seccomp
 weight: 20
 ---
 

--- a/content/docs/languages/c-cpp/_index.md
+++ b/content/docs/languages/c-cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "C/C++ Security Checklist"
-slug: lang-c-cpp
+slug: c-cpp
 weight: 1
 bookCollapseSection: true
 ---


### PR DESCRIPTION
Match the Rust section's short-slug convention (drop the lang-c-cpp- prefix). Add page-relative aliases so the old
/docs/languages/c-cpp/lang-c-cpp-* URLs redirect to the new paths.